### PR TITLE
Chnage minimun jacooc value form 70 to 10

### DIFF
--- a/userapi/pom.xml
+++ b/userapi/pom.xml
@@ -209,12 +209,12 @@
 										<limit>
 											<counter>INSTRUCTION</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.70</minimum>
+											<minimum>0.10</minimum>
 										</limit>
 										<limit>
 											<counter>BRANCH</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.70</minimum>
+											<minimum>0.10</minimum>
 										</limit>
 									</limits>
 								</rule>


### PR DESCRIPTION
## Summary by Sourcery

Lower Jacoco coverage thresholds in userapi module

CI:
- Reduce instruction coverage minimum to 10%
- Reduce branch coverage minimum to 10%